### PR TITLE
Case insensitive checks. Fix check for multipart/related.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for _, a := range(email.Attachments) {
 
 ## Retrieving embedded files
 
-You can access embedded files in the same way you can access attachments. THey contain the mime type, data stream and content id that is used to reference them through the email.
+You can access embedded files in the same way you can access attachments. They contain the mime type, data stream and content id that is used to reference them through the email.
 
 ```go
 var reader io.Reader

--- a/parsemail.go
+++ b/parsemail.go
@@ -189,7 +189,7 @@ func parseMultipartAlternative(msg io.Reader, boundary string) (textBody, htmlBo
 
 			htmlBody += strings.TrimSuffix(string(ppContent[:]), "\n")
 		case contentTypeMultipartRelated:
-			tb, hb, ef, err := parseMultipartAlternative(part, params["boundary"])
+			tb, hb, ef, err := parseMultipartRelated(part, params["boundary"])
 			if err != nil {
 				return textBody, htmlBody, embeddedFiles, err
 			}

--- a/parsemail.go
+++ b/parsemail.go
@@ -232,7 +232,7 @@ func decodeHeaderMime(header mail.Header) (mail.Header, error) {
 func decodePartData(part *multipart.Part) (io.Reader, error) {
 	encoding := part.Header.Get("Content-Transfer-Encoding")
 
-	if encoding == "base64" {
+	if strings.EqualFold(encoding, "base64") {
 		dr := base64.NewDecoder(base64.StdEncoding, part)
 		dd, err := ioutil.ReadAll(dr)
 		if err != nil {


### PR DESCRIPTION
1. Use case-insensitive string compare for when checking for the `Content-Transfer-Encoding` header. An email I received from Apple via Gmail was sending the header `Content-Transfer-Encoding: Base64`.
1. Add check for `multipart/related` in `parseMultipartMixed`. In another email I sent to my Gmail, I included an inline picture and an attachment. The email was structured like:
```
multipart/mixed
  multipart/related
    multipart/alternative
      text/plain
      text/html
    image/jpeg (INLINE)
  image/png (ATTACHMENT)
```