### PR TITLE
Fixed TestParseMail

### DIFF
--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -248,7 +248,11 @@ So, "Hello".`,
 	}
 
 	for index, td := range testData {
-		e, err := Parse(strings.NewReader(td.mailData))
+		m, err := mail.ReadMessage(strings.NewReader(td.mailData))
+		if err != nil {
+			t.Error(err)
+		}
+		e, err := Parse(m)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Test was failing with the message below:
`parsemail\parsemail_test.go:251:36: cannot use strings.NewReader(td.mailData) (type *strings.Reader) as type *mail.Message in argument to Parse`