### PR TITLE
Fix time

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/mail"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -375,6 +376,8 @@ func (hp headerParser) parseAddressList(s string) (ma []*mail.Address) {
 	return
 }
 
+var timezoneRegex = regexp.MustCompile(` \([A-Za-z0-9]+\)$`)
+
 func (hp headerParser) parseTime(s string) (t time.Time) {
 	if hp.err != nil || s == "" {
 		return
@@ -384,6 +387,8 @@ func (hp headerParser) parseTime(s string) (t time.Time) {
 	if hp.err == nil {
 		return t
 	}
+
+	s = timezoneRegex.ReplaceAllString(s, "")
 
 	t, hp.err = time.Parse("Mon, 2 Jan 2006 15:04:05 -0700", s)
 

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -597,7 +597,7 @@ So, "Hello".
 var rfc5322exampleA12 = `From: "Joe Q. Public" <john.q.public@example.com>
 To: Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>
 Cc: <boss@nil.test>, "Giant; \"Big\" Box" <sysservices@example.net>
-Date: Tue, 1 Jul 2003 10:52:37 +0200
+Date: Tue, 1 Jul 2003 10:52:37 +0200 (GMT)
 Message-ID: <5678.21-Nov-1997@example.com>
 
 Hi everyone.

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -248,11 +248,7 @@ So, "Hello".`,
 	}
 
 	for index, td := range testData {
-		m, err := mail.ReadMessage(strings.NewReader(td.mailData))
-		if err != nil {
-			t.Error(err)
-		}
-		e, err := Parse(m)
+		e, err := Parse(strings.NewReader(td.mailData))
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Where a date string ends with a timezone suffix - e.g. (GMT) - strip this off as it is redundant but some email servers will add it