### PR TITLE
Fixed parse error with text/plain on multipart/mixed email

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -234,6 +234,11 @@ func parseMultipartMixed(msg io.Reader, boundary string) (textBody, htmlBody str
 			if err != nil {
 				return textBody, htmlBody, attachments, embeddedFiles, err
 			}
+		} else if contentType == contentTypeTextPlain {
+			textBody, htmlBody, embeddedFiles, err = parseMultipartRelated(msg, boundary)
+			if err != nil {
+				return textBody, htmlBody, attachments, embeddedFiles, err
+			}
 		} else if contentType == contentTypeMultipartRelated {
 			textBody, htmlBody, embeddedFiles, err = parseMultipartRelated(part, params["boundary"])
 			if err != nil {

--- a/parsemail.go
+++ b/parsemail.go
@@ -235,10 +235,12 @@ func parseMultipartMixed(msg io.Reader, boundary string) (textBody, htmlBody str
 				return textBody, htmlBody, attachments, embeddedFiles, err
 			}
 		} else if contentType == contentTypeTextPlain {
-			textBody, htmlBody, embeddedFiles, err = parseMultipartRelated(msg, boundary)
+			ppContent, err := ioutil.ReadAll(part)
 			if err != nil {
 				return textBody, htmlBody, attachments, embeddedFiles, err
 			}
+
+			textBody += strings.TrimSuffix(string(ppContent[:]), "\n")
 		} else if contentType == contentTypeMultipartRelated {
 			textBody, htmlBody, embeddedFiles, err = parseMultipartRelated(part, params["boundary"])
 			if err != nil {


### PR DESCRIPTION
I had an email of type `multipart/mixed` with a section of type `text/plain` that was returning errors to parse.

This fixed the issue, thought I'd share the code.  Not sure if this is the right fix, open to feedback!