### PR TITLE
fix go.mod to this repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/EdwinLove/parsemail
+module github.com/DusanKasan/parsemail
 
 go 1.12


### PR DESCRIPTION
looks like this file was added recently in https://github.com/DusanKasan/parsemail/pull/8/files but it's pointed at the other repo, so it doesn't actually allow someone using modules to import this one. 