### PR TITLE
converts encoding to lowercase

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -345,7 +345,7 @@ func decodeAttachment(part *multipart.Part) (at Attachment, err error) {
 }
 
 func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
-	switch encoding {
+	switch strings.ToLower(encoding) {
 	case "base64":
 		decoded := base64.NewDecoder(base64.StdEncoding, content)
 		b, err := ioutil.ReadAll(decoded)


### PR DESCRIPTION
Hey, great little library, saved me a bunch of time.

I've run into some minor issues with third parties sending emails with "Content-Transfer-Encoding" set to "Base64" rather than "base64". This PR addresses that issue for me, but I'm not sure if you'll want to merge considering it's technically incorrect. 

Cheers