### PR TITLE
Add support binary encoding

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -361,7 +361,7 @@ func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
 		}
 
 		return bytes.NewReader(dd), nil
-	case "":
+	case "binary", "":
 		return content, nil
 	default:
 		return nil, fmt.Errorf("unknown encoding: %s", encoding)
@@ -483,7 +483,7 @@ type Email struct {
 	ResentMessageID string
 
 	ContentType string
-	Content io.Reader
+	Content     io.Reader
 
 	HTMLBody string
 	TextBody string


### PR DESCRIPTION
As indicated in the  https://tools.ietf.org/html/rfc2045#section-6.1  Content-Transfer-Encoding may be *binary*. I'm added suport this encoding.