### PR TITLE
Add 8bit and binary decoding support

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -354,7 +354,7 @@ func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
 		}
 
 		return bytes.NewReader(b), nil
-	case "7bit":
+	case "7bit", "8bit", "binary:
 		dd, err := ioutil.ReadAll(content)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
According to "Content-Transfer-Encoding" section of RFC 1341:

> The values "8bit", "7bit", and "binary" all imply that NO encoding has been performed...

CHANGE LOG:
- Add 8bit support for content decoding.
- Add binary support for content decoding.