### PR TITLE
Handle missing Content-Type in multipart/alternative as plain text

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -171,7 +171,11 @@ func parseMultipartAlternative(msg io.Reader, boundary string) (textBody, htmlBo
 			return textBody, htmlBody, embeddedFiles, err
 		}
 
-		contentType, params, err := mime.ParseMediaType(part.Header.Get("Content-Type"))
+		var contentTypeHeader = part.Header.Get("Content-Type")
+		if len(contentTypeHeader) == 0 {
+			contentTypeHeader = contentTypeTextPlain
+		}
+		contentType, params, err := mime.ParseMediaType(contentTypeHeader)
 		if err != nil {
 			return textBody, htmlBody, embeddedFiles, err
 		}

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -898,6 +898,8 @@ Content-Type: multipart/related; boundary="000000000000ab2e2205a26de587"
 Content-Type: multipart/alternative; boundary="000000000000ab2e1f05a26de586"
 
 --000000000000ab2e1f05a26de586
+
+--000000000000ab2e1f05a26de586
 Content-Type: text/plain; charset="UTF-8"
 
 Time for the egg.


### PR DESCRIPTION
I encountered an email with a blank entry in a multipart/alternative section.

I did not check the spec to see if this is the best way to handle this error but it works in my situation and in the new test case.

Prior to this change:

```
mime: no media type
```

After this change:

Tests Pass