### PR TITLE
Check for attachments when parsing text/plain part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Binaries
+bin/
+*debug*bin
+
+# Env variables
+.envrc
+.env
+
+# IDEs
+.idea/
+*.iml
+.DS_Store
+.vscode/
+*.code-workspace

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/DusanKasan/parsemail
+module github.com/ggarciajr/parsemail
 
-go 1.12
+go 1.13

--- a/parsemail.go
+++ b/parsemail.go
@@ -258,12 +258,21 @@ func parseMultipartMixed(msg io.Reader, boundary string) (textBody, htmlBody str
 				return textBody, htmlBody, attachments, embeddedFiles, err
 			}
 		} else if contentType == contentTypeTextPlain {
-			ppContent, err := ioutil.ReadAll(part)
-			if err != nil {
-				return textBody, htmlBody, attachments, embeddedFiles, err
-			}
+			if isAttachment(part) {
+				at, err := decodeAttachment(part)
+				if err != nil {
+					return textBody, htmlBody, attachments, embeddedFiles, err
+				}
 
-			textBody += strings.TrimSuffix(string(ppContent[:]), "\n")
+				attachments = append(attachments, at)
+			} else {
+				ppContent, err := ioutil.ReadAll(part)
+				if err != nil {
+					return textBody, htmlBody, attachments, embeddedFiles, err
+				}
+
+				textBody += strings.TrimSuffix(string(ppContent[:]), "\n")
+			}
 		} else if contentType == contentTypeTextHtml {
 			ppContent, err := ioutil.ReadAll(part)
 			if err != nil {

--- a/parsemail.go
+++ b/parsemail.go
@@ -114,7 +114,12 @@ func parseMultipartRelated(msg io.Reader, boundary string) (textBody, htmlBody s
 			return textBody, htmlBody, embeddedFiles, err
 		}
 
-		contentType, params, err := mime.ParseMediaType(part.Header.Get("Content-Type"))
+		hContentType := strings.TrimSpace(part.Header.Get("Content-Type"))
+		if len(hContentType) == 0 {
+			continue
+		}
+
+		contentType, params, err := mime.ParseMediaType(hContentType)
 		if err != nil {
 			return textBody, htmlBody, embeddedFiles, err
 		}
@@ -171,7 +176,12 @@ func parseMultipartAlternative(msg io.Reader, boundary string) (textBody, htmlBo
 			return textBody, htmlBody, embeddedFiles, err
 		}
 
-		contentType, params, err := mime.ParseMediaType(part.Header.Get("Content-Type"))
+		hContentType := strings.TrimSpace(part.Header.Get("Content-Type"))
+		if len(hContentType) == 0 {
+			continue
+		}
+
+		contentType, params, err := mime.ParseMediaType(hContentType)
 		if err != nil {
 			return textBody, htmlBody, embeddedFiles, err
 		}
@@ -227,7 +237,12 @@ func parseMultipartMixed(msg io.Reader, boundary string) (textBody, htmlBody str
 			return textBody, htmlBody, attachments, embeddedFiles, err
 		}
 
-		contentType, params, err := mime.ParseMediaType(part.Header.Get("Content-Type"))
+		hContentType := strings.TrimSpace(part.Header.Get("Content-Type"))
+		if len(hContentType) == 0 {
+			continue
+		}
+
+		contentType, params, err := mime.ParseMediaType(hContentType)
 		if err != nil {
 			return textBody, htmlBody, attachments, embeddedFiles, err
 		}

--- a/parsemail.go
+++ b/parsemail.go
@@ -366,7 +366,7 @@ func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
 		}
 
 		return bytes.NewReader(b), nil
-	case "7bit":
+	case "7bit", "8bit":
 		dd, err := ioutil.ReadAll(content)
 		if err != nil {
 			return nil, err

--- a/parsemail.go
+++ b/parsemail.go
@@ -345,7 +345,7 @@ func decodeAttachment(part *multipart.Part) (at Attachment, err error) {
 }
 
 func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
-	switch encoding {
+	switch strings.ToLower(encoding) {
 	case "base64":
 		decoded := base64.NewDecoder(base64.StdEncoding, content)
 		b, err := ioutil.ReadAll(decoded)
@@ -483,7 +483,7 @@ type Email struct {
 	ResentMessageID string
 
 	ContentType string
-	Content io.Reader
+	Content     io.Reader
 
 	HTMLBody string
 	TextBody string

--- a/parsemail.go
+++ b/parsemail.go
@@ -271,6 +271,19 @@ func parseMultipartMixed(msg io.Reader, boundary string) (textBody, htmlBody str
 			}
 
 			htmlBody += strings.TrimSuffix(string(ppContent[:]), "\n")
+		} else if contentType == contentTypeMultipartMixed {
+			textBody2, htmlBody2, attachments2, embeddedFiles2, err := parseMultipartMixed(part, params["boundary"])
+			if err != nil {
+				return textBody, htmlBody, attachments, embeddedFiles, err
+			}
+			textBody += textBody2
+			htmlBody += htmlBody2
+			if attachments2 != nil {
+				attachments = append(attachments, attachments2...)
+			}
+			if embeddedFiles2 != nil {
+				embeddedFiles = append(embeddedFiles, embeddedFiles2...)
+			}
 		} else if isAttachment(part) {
 			at, err := decodeAttachment(part)
 			if err != nil {

--- a/parsemail.go
+++ b/parsemail.go
@@ -326,12 +326,24 @@ func decodeEmbeddedFile(part *multipart.Part) (ef EmbeddedFile, err error) {
 	return
 }
 
+func partFileName(part *multipart.Part) string {
+	if part.FileName() != "" {
+		return part.FileName()
+	}
+	v := part.Header.Get("Content-Type")
+	_, contentTypeParams, err := mime.ParseMediaType(v)
+	if err != nil {
+		return ""
+	}
+	return contentTypeParams["name"]
+}
+
 func isAttachment(part *multipart.Part) bool {
-	return part.FileName() != ""
+	return partFileName(part) != ""
 }
 
 func decodeAttachment(part *multipart.Part) (at Attachment, err error) {
-	filename := decodeMimeSentence(part.FileName())
+	filename := decodeMimeSentence(partFileName(part))
 	decoded, err := decodeContent(part, part.Header.Get("Content-Transfer-Encoding"))
 	if err != nil {
 		return

--- a/parsemail.go
+++ b/parsemail.go
@@ -381,15 +381,13 @@ func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
 		}
 
 		return bytes.NewReader(b), nil
-	case "7bit", "8bit":
+	case "", "7bit", "8bit":
 		dd, err := ioutil.ReadAll(content)
 		if err != nil {
 			return nil, err
 		}
 
 		return bytes.NewReader(dd), nil
-	case "":
-		return content, nil
 	default:
 		return nil, fmt.Errorf("unknown encoding: %s", encoding)
 	}

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -489,182 +489,184 @@ So, "Hello".`,
 	}
 
 	for index, td := range testData {
-		e, err := Parse(strings.NewReader(td.mailData))
-		if err != nil {
-			t.Error(err)
-		}
-
-		if td.contentType != e.ContentType {
-			t.Errorf("[Test Case %v] Wrong content type. Expected: %s, Got: %s", index, td.contentType, e.ContentType)
-		}
-
-		if td.content != "" {
-			b, err := ioutil.ReadAll(e.Content)
+		t.Run(fmt.Sprintf("test case %d", index), func(t *testing.T) {
+			e, err := Parse(strings.NewReader(td.mailData))
 			if err != nil {
 				t.Error(err)
-			} else if td.content != string(b) {
-				t.Errorf("[Test Case %v] Wrong content. Expected: %s, Got: %s", index, td.content, string(b))
 			}
-		}
 
-		if td.subject != e.Subject {
-			t.Errorf("[Test Case %v] Wrong subject. Expected: %s, Got: %s", index, td.subject, e.Subject)
-		}
+			if td.contentType != e.ContentType {
+				t.Errorf("[Test Case %v] Wrong content type. Expected: %s, Got: %s", index, td.contentType, e.ContentType)
+			}
 
-		if td.messageID != e.MessageID {
-			t.Errorf("[Test Case %v] Wrong messageID. Expected: '%s', Got: '%s'", index, td.messageID, e.MessageID)
-		}
-
-		if !td.date.Equal(e.Date) {
-			t.Errorf("[Test Case %v] Wrong date. Expected: %v, Got: %v", index, td.date, e.Date)
-		}
-
-		d := dereferenceAddressList(e.From)
-		if !assertAddressListEq(td.from, d) {
-			t.Errorf("[Test Case %v] Wrong from. Expected: %s, Got: %s", index, td.from, d)
-		}
-
-		var sender mail.Address
-		if e.Sender != nil {
-			sender = *e.Sender
-		}
-		if td.sender != sender {
-			t.Errorf("[Test Case %v] Wrong sender. Expected: %s, Got: %s", index, td.sender, sender)
-		}
-
-		d = dereferenceAddressList(e.To)
-		if !assertAddressListEq(td.to, d) {
-			t.Errorf("[Test Case %v] Wrong to. Expected: %s, Got: %s", index, td.to, d)
-		}
-
-		d = dereferenceAddressList(e.Cc)
-		if !assertAddressListEq(td.cc, d) {
-			t.Errorf("[Test Case %v] Wrong cc. Expected: %s, Got: %s", index, td.cc, d)
-		}
-
-		d = dereferenceAddressList(e.Bcc)
-		if !assertAddressListEq(td.bcc, d) {
-			t.Errorf("[Test Case %v] Wrong bcc. Expected: %s, Got: %s", index, td.bcc, d)
-		}
-
-		if td.resentMessageID != e.ResentMessageID {
-			t.Errorf("[Test Case %v] Wrong resent messageID. Expected: '%s', Got: '%s'", index, td.resentMessageID, e.ResentMessageID)
-		}
-
-		if !td.resentDate.Equal(e.ResentDate) && !td.resentDate.IsZero() && !e.ResentDate.IsZero() {
-			t.Errorf("[Test Case %v] Wrong resent date. Expected: %v, Got: %v", index, td.resentDate, e.ResentDate)
-		}
-
-		d = dereferenceAddressList(e.ResentFrom)
-		if !assertAddressListEq(td.resentFrom, d) {
-			t.Errorf("[Test Case %v] Wrong resent from. Expected: %s, Got: %s", index, td.resentFrom, d)
-		}
-
-		var resentSender mail.Address
-		if e.ResentSender != nil {
-			resentSender = *e.ResentSender
-		}
-		if td.resentSender != resentSender {
-			t.Errorf("[Test Case %v] Wrong resent sender. Expected: %s, Got: %s", index, td.resentSender, resentSender)
-		}
-
-		d = dereferenceAddressList(e.ResentTo)
-		if !assertAddressListEq(td.resentTo, d) {
-			t.Errorf("[Test Case %v] Wrong resent to. Expected: %s, Got: %s", index, td.resentTo, d)
-		}
-
-		d = dereferenceAddressList(e.ResentCc)
-		if !assertAddressListEq(td.resentCc, d) {
-			t.Errorf("[Test Case %v] Wrong resent cc. Expected: %s, Got: %s", index, td.resentCc, d)
-		}
-
-		d = dereferenceAddressList(e.ResentBcc)
-		if !assertAddressListEq(td.resentBcc, d) {
-			t.Errorf("[Test Case %v] Wrong resent bcc. Expected: %s, Got: %s", index, td.resentBcc, d)
-		}
-
-		if !assertSliceEq(td.inReplyTo, e.InReplyTo) {
-			t.Errorf("[Test Case %v] Wrong in reply to. Expected: %s, Got: %s", index, td.inReplyTo, e.InReplyTo)
-		}
-
-		if !assertSliceEq(td.references, e.References) {
-			t.Errorf("[Test Case %v] Wrong references. Expected: %s, Got: %s", index, td.references, e.References)
-		}
-
-		d = dereferenceAddressList(e.ReplyTo)
-		if !assertAddressListEq(td.replyTo, d) {
-			t.Errorf("[Test Case %v] Wrong reply to. Expected: %s, Got: %s", index, td.replyTo, d)
-		}
-
-		if td.htmlBody != e.HTMLBody {
-			t.Errorf("[Test Case %v] Wrong html body. Expected: '%s', Got: '%s'", index, td.htmlBody, e.HTMLBody)
-		}
-
-		if td.textBody != e.TextBody {
-			t.Errorf("[Test Case %v] Wrong text body. Expected: '%s', Got: '%s'", index, td.textBody, e.TextBody)
-		}
-
-		if len(td.attachments) != len(e.Attachments) {
-			t.Errorf("[Test Case %v] Incorrect number of attachments! Expected: %v, Got: %v.", index, len(td.attachments), len(e.Attachments))
-		} else {
-			attachs := e.Attachments[:]
-
-			for _, ad := range td.attachments {
-				found := false
-
-				for i, ra := range attachs {
-					b, err := ioutil.ReadAll(ra.Data)
-					if err != nil {
-						t.Error(err)
-					}
-
-					if ra.Filename == ad.filename && string(b) == ad.data && ra.ContentType == ad.contentType {
-						found = true
-						attachs = append(attachs[:i], attachs[i+1:]...)
-					}
-				}
-
-				if !found {
-					t.Errorf("[Test Case %v] Attachment not found: %s", index, ad.filename)
+			if td.content != "" {
+				b, err := ioutil.ReadAll(e.Content)
+				if err != nil {
+					t.Error(err)
+				} else if td.content != string(b) {
+					t.Errorf("[Test Case %v] Wrong content. Expected: %s, Got: %s", index, td.content, string(b))
 				}
 			}
 
-			if len(attachs) != 0 {
-				t.Errorf("[Test Case %v] Email contains %v unexpected attachments: %v", index, len(attachs), attachs)
+			if td.subject != e.Subject {
+				t.Errorf("[Test Case %v] Wrong subject. Expected: %s, Got: %s", index, td.subject, e.Subject)
 			}
-		}
 
-		if len(td.embeddedFiles) != len(e.EmbeddedFiles) {
-			t.Errorf("[Test Case %v] Incorrect number of embedded files! Expected: %v, Got: %v.", index, len(td.embeddedFiles), len(e.EmbeddedFiles))
-		} else {
-			embeds := e.EmbeddedFiles[:]
+			if td.messageID != e.MessageID {
+				t.Errorf("[Test Case %v] Wrong messageID. Expected: '%s', Got: '%s'", index, td.messageID, e.MessageID)
+			}
 
-			for _, ad := range td.embeddedFiles {
-				found := false
+			if !td.date.Equal(e.Date) {
+				t.Errorf("[Test Case %v] Wrong date. Expected: %v, Got: %v", index, td.date, e.Date)
+			}
 
-				for i, ra := range embeds {
-					b, err := ioutil.ReadAll(ra.Data)
-					if err != nil {
-						t.Error(err)
+			d := dereferenceAddressList(e.From)
+			if !assertAddressListEq(td.from, d) {
+				t.Errorf("[Test Case %v] Wrong from. Expected: %s, Got: %s", index, td.from, d)
+			}
+
+			var sender mail.Address
+			if e.Sender != nil {
+				sender = *e.Sender
+			}
+			if td.sender != sender {
+				t.Errorf("[Test Case %v] Wrong sender. Expected: %s, Got: %s", index, td.sender, sender)
+			}
+
+			d = dereferenceAddressList(e.To)
+			if !assertAddressListEq(td.to, d) {
+				t.Errorf("[Test Case %v] Wrong to. Expected: %s, Got: %s", index, td.to, d)
+			}
+
+			d = dereferenceAddressList(e.Cc)
+			if !assertAddressListEq(td.cc, d) {
+				t.Errorf("[Test Case %v] Wrong cc. Expected: %s, Got: %s", index, td.cc, d)
+			}
+
+			d = dereferenceAddressList(e.Bcc)
+			if !assertAddressListEq(td.bcc, d) {
+				t.Errorf("[Test Case %v] Wrong bcc. Expected: %s, Got: %s", index, td.bcc, d)
+			}
+
+			if td.resentMessageID != e.ResentMessageID {
+				t.Errorf("[Test Case %v] Wrong resent messageID. Expected: '%s', Got: '%s'", index, td.resentMessageID, e.ResentMessageID)
+			}
+
+			if !td.resentDate.Equal(e.ResentDate) && !td.resentDate.IsZero() && !e.ResentDate.IsZero() {
+				t.Errorf("[Test Case %v] Wrong resent date. Expected: %v, Got: %v", index, td.resentDate, e.ResentDate)
+			}
+
+			d = dereferenceAddressList(e.ResentFrom)
+			if !assertAddressListEq(td.resentFrom, d) {
+				t.Errorf("[Test Case %v] Wrong resent from. Expected: %s, Got: %s", index, td.resentFrom, d)
+			}
+
+			var resentSender mail.Address
+			if e.ResentSender != nil {
+				resentSender = *e.ResentSender
+			}
+			if td.resentSender != resentSender {
+				t.Errorf("[Test Case %v] Wrong resent sender. Expected: %s, Got: %s", index, td.resentSender, resentSender)
+			}
+
+			d = dereferenceAddressList(e.ResentTo)
+			if !assertAddressListEq(td.resentTo, d) {
+				t.Errorf("[Test Case %v] Wrong resent to. Expected: %s, Got: %s", index, td.resentTo, d)
+			}
+
+			d = dereferenceAddressList(e.ResentCc)
+			if !assertAddressListEq(td.resentCc, d) {
+				t.Errorf("[Test Case %v] Wrong resent cc. Expected: %s, Got: %s", index, td.resentCc, d)
+			}
+
+			d = dereferenceAddressList(e.ResentBcc)
+			if !assertAddressListEq(td.resentBcc, d) {
+				t.Errorf("[Test Case %v] Wrong resent bcc. Expected: %s, Got: %s", index, td.resentBcc, d)
+			}
+
+			if !assertSliceEq(td.inReplyTo, e.InReplyTo) {
+				t.Errorf("[Test Case %v] Wrong in reply to. Expected: %s, Got: %s", index, td.inReplyTo, e.InReplyTo)
+			}
+
+			if !assertSliceEq(td.references, e.References) {
+				t.Errorf("[Test Case %v] Wrong references. Expected: %s, Got: %s", index, td.references, e.References)
+			}
+
+			d = dereferenceAddressList(e.ReplyTo)
+			if !assertAddressListEq(td.replyTo, d) {
+				t.Errorf("[Test Case %v] Wrong reply to. Expected: %s, Got: %s", index, td.replyTo, d)
+			}
+
+			if td.htmlBody != e.HTMLBody {
+				t.Errorf("[Test Case %v] Wrong html body. Expected: '%s', Got: '%s'", index, td.htmlBody, e.HTMLBody)
+			}
+
+			if td.textBody != e.TextBody {
+				t.Errorf("[Test Case %v] Wrong text body. Expected: '%s', Got: '%s'", index, td.textBody, e.TextBody)
+			}
+
+			if len(td.attachments) != len(e.Attachments) {
+				t.Errorf("[Test Case %v] Incorrect number of attachments! Expected: %v, Got: %v.", index, len(td.attachments), len(e.Attachments))
+			} else {
+				attachs := e.Attachments[:]
+
+				for _, ad := range td.attachments {
+					found := false
+
+					for i, ra := range attachs {
+						b, err := ioutil.ReadAll(ra.Data)
+						if err != nil {
+							t.Error(err)
+						}
+
+						if ra.Filename == ad.filename && string(b) == ad.data && ra.ContentType == ad.contentType {
+							found = true
+							attachs = append(attachs[:i], attachs[i+1:]...)
+						}
 					}
 
-					encoded := base64.StdEncoding.EncodeToString(b)
-
-					if ra.CID == ad.cid && encoded == ad.base64data && ra.ContentType == ad.contentType {
-						found = true
-						embeds = append(embeds[:i], embeds[i+1:]...)
+					if !found {
+						t.Errorf("[Test Case %v] Attachment not found: %s", index, ad.filename)
 					}
 				}
 
-				if !found {
-					t.Errorf("[Test Case %v] Embedded file not found: %s", index, ad.cid)
+				if len(attachs) != 0 {
+					t.Errorf("[Test Case %v] Email contains %v unexpected attachments: %v", index, len(attachs), attachs)
 				}
 			}
 
-			if len(embeds) != 0 {
-				t.Errorf("[Test Case %v] Email contains %v unexpected embedded files: %v", index, len(embeds), embeds)
+			if len(td.embeddedFiles) != len(e.EmbeddedFiles) {
+				t.Errorf("[Test Case %v] Incorrect number of embedded files! Expected: %v, Got: %v.", index, len(td.embeddedFiles), len(e.EmbeddedFiles))
+			} else {
+				embeds := e.EmbeddedFiles[:]
+
+				for _, ad := range td.embeddedFiles {
+					found := false
+
+					for i, ra := range embeds {
+						b, err := ioutil.ReadAll(ra.Data)
+						if err != nil {
+							t.Error(err)
+						}
+
+						encoded := base64.StdEncoding.EncodeToString(b)
+
+						if ra.CID == ad.cid && encoded == ad.base64data && ra.ContentType == ad.contentType {
+							found = true
+							embeds = append(embeds[:i], embeds[i+1:]...)
+						}
+					}
+
+					if !found {
+						t.Errorf("[Test Case %v] Embedded file not found: %s", index, ad.cid)
+					}
+				}
+
+				if len(embeds) != 0 {
+					t.Errorf("[Test Case %v] Email contains %v unexpected embedded files: %v", index, len(embeds), embeds)
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -486,6 +486,34 @@ So, "Hello".`,
 				},
 			},
 		},
+		17: {
+			mailData:    data5,
+			contentType: `multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf`,
+			content:     "",
+			subject:     "Peter Paholík",
+			from: []mail.Address{
+				{
+					Name:    "Peter Paholík",
+					Address: "peter.paholik@gmail.com",
+				},
+			},
+			to: []mail.Address{
+				{
+					Name:    "",
+					Address: "dusan@kasan.sk",
+				},
+			},
+			messageID: "CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com",
+			date:      parseDate("Fri, 07 Apr 2017 09:17:26 +0200"),
+			htmlBody:  "<div dir=\"ltr\"><br></div>",
+			attachments: []attachmentData{
+				{
+					filename:    "text-file.txt",
+					contentType: "text/plain",
+					data:        "text file attachment sent as text/plain content-type",
+				},
+			},
+		},
 	}
 
 	for index, td := range testData {
@@ -898,6 +926,38 @@ Content-Transfer-Encoding: base64
 X-Attachment-Id: f_j17i0f0d0
 
 WzEsIDIsIDNd
+--f403045f1dcc043a44054c8e6bbf--
+`
+
+var data5 = `From: =?UTF-8?Q?Peter_Pahol=C3=ADk?= <peter.paholik@gmail.com>
+Date: Fri, 7 Apr 2017 09:17:26 +0200
+Message-ID: <CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com>
+Subject: =?UTF-8?Q?Peter_Pahol=C3=ADk?=
+To: dusan@kasan.sk
+Content-Type: multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf
+
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: multipart/alternative; boundary=f403045f1dcc043a3f054c8e6bbd
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Transfer-Encoding: 7bit
+
+
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Type: text/html; charset=UTF-8
+
+<div dir="ltr"><br></div>
+
+--f403045f1dcc043a3f054c8e6bbd--
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: text/plain;
+	name="text-file.txt"
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_j17i0f0d0
+
+dGV4dCBmaWxlIGF0dGFjaG1lbnQgc2VudCBhcyB0ZXh0L3BsYWluIGNvbnRlbnQtdHlwZQ==
 --f403045f1dcc043a44054c8e6bbf--
 `
 

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -957,8 +957,8 @@ Message-ID: <5678.21-Nov-1997@example.com>
 Hi everyone.
 `
 
-//todo: not yet implemented in net/mail
-//once there is support for this, add it
+// todo: not yet implemented in net/mail
+// once there is support for this, add it
 var rfc5322exampleA13 = `From: Pete <pete@silly.example>
 To: A Group:Ed Jones <c@a.test>,joe@where.test,John <jdoe@one.test>;
 Cc: Undisclosed recipients:;
@@ -968,7 +968,7 @@ Message-ID: <testabcd.1234@silly.example>
 Testing.
 `
 
-//we skipped the first message bcause it's the same as A 1.1
+// we skipped the first message bcause it's the same as A 1.1
 var rfc5322exampleA2a = `From: Mary Smith <mary@example.net>
 To: John Doe <jdoe@machine.example>
 Reply-To: "Mary Smith: Personal Account" <smith@home.example>

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -458,6 +458,34 @@ So, "Hello".`,
 				},
 			},
 		},
+		16: {
+			mailData:    data4,
+			contentType: `multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf`,
+			content:     "",
+			subject:     "Peter Paholík",
+			from: []mail.Address{
+				{
+					Name:    "Peter Paholík",
+					Address: "peter.paholik@gmail.com",
+				},
+			},
+			to: []mail.Address{
+				{
+					Name:    "",
+					Address: "dusan@kasan.sk",
+				},
+			},
+			messageID: "CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com",
+			date:      parseDate("Fri, 07 Apr 2017 09:17:26 +0200"),
+			htmlBody:  "<div dir=\"ltr\"><br></div>",
+			attachments: []attachmentData{
+				{
+					filename:    "Peter Paholík 1 4 2017 2017-04-07.json",
+					contentType: "application/json",
+					data:        "[1, 2, 3]",
+				},
+			},
+		},
 	}
 
 	for index, td := range testData {
@@ -817,6 +845,39 @@ Content-Type: multipart/alternative; boundary=f403045f1dcc043a3f054c8e6bbd
 
 --f403045f1dcc043a3f054c8e6bbd
 Content-Type: text/plain; charset=UTF-8
+
+
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Type: text/html; charset=UTF-8
+
+<div dir="ltr"><br></div>
+
+--f403045f1dcc043a3f054c8e6bbd--
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: application/json;
+	name="=?UTF-8?Q?Peter_Paholi=CC=81k_1?=
+	=?UTF-8?Q?_4_2017_2017=2D04=2D07=2Ejson?="
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_j17i0f0d0
+
+WzEsIDIsIDNd
+--f403045f1dcc043a44054c8e6bbf--
+`
+
+var data4 = `From: =?UTF-8?Q?Peter_Pahol=C3=ADk?= <peter.paholik@gmail.com>
+Date: Fri, 7 Apr 2017 09:17:26 +0200
+Message-ID: <CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com>
+Subject: =?UTF-8?Q?Peter_Pahol=C3=ADk?=
+To: dusan@kasan.sk
+Content-Type: multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf
+
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: multipart/alternative; boundary=f403045f1dcc043a3f054c8e6bbd
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Transfer-Encoding: 7bit
 
 
 

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -274,7 +274,7 @@ So, "Hello".`,
 			messageID:   "1234@local.machine.example",
 			date:        parseDate("Fri, 21 Nov 1997 09:55:06 -0600"),
 			contentType: `image/jpeg; x-unix-mode=0644; name="image.gif"`,
-			content:     `GIF89a;`,
+			content: `GIF89a;`,
 		},
 		9: {
 			contentType: `multipart/mixed; boundary="0000000000007e2bb40587e36196"`,
@@ -372,15 +372,15 @@ So, "Hello".`,
 			htmlBody:  "<div dir=\"ltr\"><br></div>",
 			attachments: []attachmentData{
 				{
-					filename:      "unencoded.csv",
-					contentType:   "application/csv",
-					data: fmt.Sprintf("\n"+`"%s", "%s", "%s", "%s", "%s"`+"\n"+`"%s", "%s", "%s", "%s", "%s"`+"\n", "Some", "Data", "In", "Csv", "Format", "Foo", "Bar", "Baz", "Bum", "Poo"),
+					filename:    "unencoded.csv",
+					contentType: "application/csv",
+					data:        fmt.Sprintf("\n"+`"%s", "%s", "%s", "%s", "%s"`+"\n"+`"%s", "%s", "%s", "%s", "%s"`+"\n", "Some", "Data", "In", "Csv", "Format", "Foo", "Bar", "Baz", "Bum", "Poo"),
 				},
 			},
 		},
 		13: {
 			contentType: "multipart/related; boundary=\"000000000000ab2e2205a26de587\"",
-			mailData:   multipartRelatedExample,
+			mailData:    multipartRelatedExample,
 			subject:     "Saying Hello",
 			from: []mail.Address{
 				{
@@ -389,7 +389,7 @@ So, "Hello".`,
 				},
 			},
 			sender: mail.Address{
-				Name: "Michael Jones",
+				Name:    "Michael Jones",
 				Address: "mjones@machine.example",
 			},
 			to: []mail.Address{
@@ -401,7 +401,35 @@ So, "Hello".`,
 			messageID: "1234@local.machine.example",
 			date:      parseDate("Fri, 21 Nov 1997 09:55:06 -0600"),
 			htmlBody:  "<div dir=\"ltr\"><div>Time for the egg.</div><div><br></div><div><br><br></div></div>",
-			textBody: "Time for the egg.",
+			textBody:  "Time for the egg.",
+		},
+		14: {
+			mailData:    data3,
+			contentType: `multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf`,
+			content:     "",
+			subject:     "Peter Paholík",
+			from: []mail.Address{
+				{
+					Name:    "Peter Paholík",
+					Address: "peter.paholik@gmail.com",
+				},
+			},
+			to: []mail.Address{
+				{
+					Name:    "",
+					Address: "dusan@kasan.sk",
+				},
+			},
+			messageID: "CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com",
+			date:      parseDate("Fri, 07 Apr 2017 09:17:26 +0200"),
+			htmlBody:  "<div dir=\"ltr\"><br></div>",
+			attachments: []attachmentData{
+				{
+					filename:    "Peter Paholík 1 4 2017 2017-04-07.json",
+					contentType: "application/json",
+					data:        "[1, 2, 3]",
+				},
+			},
 		},
 	}
 
@@ -595,9 +623,9 @@ func parseDate(in string) time.Time {
 }
 
 type attachmentData struct {
-	filename      string
-	contentType   string
-	data          string
+	filename    string
+	contentType string
+	data        string
 }
 
 type embeddedFileData struct {
@@ -748,6 +776,39 @@ YKUKF+Os3baUndC0pDnwNAmLy1SUr2Gw0luxQuV/AwC6cEhVV5VRrwAAAABJRU5ErkJggg==
 --------------5DB4A1356834BB602A5F88B2
 
 --------------C70C0458A558E585ACB75FB4--
+`
+
+var data3 = `From: =?UTF-8?Q?Peter_Pahol=C3=ADk?= <peter.paholik@gmail.com>
+Date: Fri, 7 Apr 2017 09:17:26 +0200
+Message-ID: <CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com>
+Subject: =?UTF-8?Q?Peter_Pahol=C3=ADk?=
+To: dusan@kasan.sk
+Content-Type: multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf
+
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: multipart/alternative; boundary=f403045f1dcc043a3f054c8e6bbd
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Type: text/plain; charset=UTF-8
+
+
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Type: text/html; charset=UTF-8
+
+<div dir="ltr"><br></div>
+
+--f403045f1dcc043a3f054c8e6bbd--
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: application/json;
+	name="=?UTF-8?Q?Peter_Paholi=CC=81k_1?=
+	=?UTF-8?Q?_4_2017_2017=2D04=2D07=2Ejson?="
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_j17i0f0d0
+
+WzEsIDIsIDNd
+--f403045f1dcc043a44054c8e6bbf--
 `
 
 var textPlainInMultipart = `From: Rares <rares@example.com>

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -379,6 +379,33 @@ So, "Hello".`,
 			},
 		},
 		13: {
+			contentType: "multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf",
+			mailData:    attachment8bit,
+			subject:     "Peter Foobar",
+			from: []mail.Address{
+				{
+					Name:    "Peter Foobar",
+					Address: "peter.foobar@gmail.com",
+				},
+			},
+			to: []mail.Address{
+				{
+					Name:    "",
+					Address: "dusan@kasan.sk",
+				},
+			},
+			messageID: "CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com",
+			date:      parseDate("Tue, 02 Apr 2019 11:12:26 +0000"),
+			htmlBody:  "<div dir=\"ltr\"><br></div>",
+			attachments: []attachmentData{
+				{
+					filename:    "unencoded.csv",
+					contentType: "application/csv",
+					data:        fmt.Sprintf("\n"+`"%s", "%s", "%s", "%s", "%s"`+"\n"+`"%s", "%s", "%s", "%s", "%s"`+"\n", "Some", "Data", "In", "Csv", "Format", "Foo", "Bar", "Baz", "Bum", "Poo"),
+				},
+			},
+		},
+		14: {
 			contentType: "multipart/related; boundary=\"000000000000ab2e2205a26de587\"",
 			mailData:    multipartRelatedExample,
 			subject:     "Saying Hello",
@@ -403,7 +430,7 @@ So, "Hello".`,
 			htmlBody:  "<div dir=\"ltr\"><div>Time for the egg.</div><div><br></div><div><br><br></div></div>",
 			textBody:  "Time for the egg.",
 		},
-		14: {
+		15: {
 			mailData:    data3,
 			contentType: `multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf`,
 			content:     "",
@@ -998,6 +1025,40 @@ Content-Type: text/html; charset=UTF-8
 Content-Type: application/csv; 
 	name="unencoded.csv"
 Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; 
+	filename="unencoded.csv"
+
+
+"Some", "Data", "In", "Csv", "Format"
+"Foo", "Bar", "Baz", "Bum", "Poo"
+
+--f403045f1dcc043a44054c8e6bbf--
+`
+var attachment8bit = `From: =?UTF-8?Q?Peter_Foobar?= <peter.foobar@gmail.com>
+Date: Tue, 2 Apr 2019 11:12:26 +0000
+Message-ID: <CACtgX4kNXE7T5XKSKeH_zEcfUUmf2vXVASxYjaaK9cCn-3zb_g@mail.gmail.com>
+Subject: =?UTF-8?Q?Peter_Foobar?=
+To: dusan@kasan.sk
+Content-Type: multipart/mixed; boundary=f403045f1dcc043a44054c8e6bbf
+
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: multipart/alternative; boundary=f403045f1dcc043a3f054c8e6bbd
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Type: text/plain; charset=UTF-8
+
+
+
+--f403045f1dcc043a3f054c8e6bbd
+Content-Type: text/html; charset=UTF-8
+
+<div dir="ltr"><br></div>
+
+--f403045f1dcc043a3f054c8e6bbd--
+--f403045f1dcc043a44054c8e6bbf
+Content-Type: application/csv; 
+	name="unencoded.csv"
+Content-Transfer-Encoding: 8bit
 Content-Disposition: attachment; 
 	filename="unencoded.csv"
 


### PR DESCRIPTION
This change makes it possible to extract attachments when parsing a text/plain content-type part